### PR TITLE
Add rudimentary individual projects page, refactor projects

### DIFF
--- a/aid/.eslintrc.js
+++ b/aid/.eslintrc.js
@@ -1,0 +1,8 @@
+module.exports = {
+    "extends": "airbnb",
+    "plugins": [
+        "react",
+        "jsx-a11y",
+        "import"
+    ]
+};

--- a/aid/components/ProjectCard.jsx
+++ b/aid/components/ProjectCard.jsx
@@ -6,6 +6,7 @@ import '~/styles/ProjectCard'
  *     title='Title'
  *     description='Description of project'
  *     image='url/to/image'
+ *     url='url/to/additional/info' // OR UNDEFINED IF NONE
  *  />
  */
 
@@ -16,7 +17,7 @@ export default class ProjectCard extends React.Component {
       <div className='ProjectCard'>
         <div className='backdrop tinted' style={{backgroundImage: backgroundImage}} />
        
-        <div className='titles'>
+        <div className='card-titles'>
           <h4>{ this.props.title }</h4>
           <h5>{ this.props.subtitle }</h5>
         </div>

--- a/aid/components/ProjectsList.jsx
+++ b/aid/components/ProjectsList.jsx
@@ -1,32 +1,17 @@
 import React from 'react'
 
 import ProjectCard from 'components/ProjectCard'
+import {getBackgroundImage, getReadMoreUrl} from 'utils/projects-helpers.js'
+
 const DEFAULT_CARD_IMAGE = '/assets/images/card1.png'
 
 export default class ProjectList extends React.Component {
   render() {
     const projects = this.props.projects.map(function(p, index) {
 
-      var backgroundImage
-      var readMoreUrl
+      let backgroundImage = getBackgroundImage(p)
+      let readMoreUrl = getReadMoreUrl(p) 
       
-      // Uses image as defined in the page.md, or
-      // default image 
-      if ('image' in p.data && p.data.image !== '') {
-        backgroundImage = p.path + p.data.image
-      } else {
-        backgroundImage = DEFAULT_CARD_IMAGE
-      }
-
-      // Sets url to either a url defined in page.md,
-      // or the url of the page if it has a body.
-      // url will be undefined otherwise.
-      if ('url' in p.data && p.data.url !== '') {
-        readMoreUrl = p.data.url
-      } else if (p.data.body !== '') {
-        readMoreUrl = p.path
-      }
-
       return (
         <ProjectCard 
           key={index}

--- a/aid/config.toml
+++ b/aid/config.toml
@@ -1,2 +1,3 @@
 siteTitle="AID Berkeley"
-linkPrefix = "/gatsby-starter-default"
+
+linkPrefix = "/"

--- a/aid/package.json
+++ b/aid/package.json
@@ -4,9 +4,13 @@
   "version": "1.0.0",
   "author": "Innovative Design 2017",
   "babel": {
-    "presets": ["react", "es2015", "stage-0"],
+    "presets": [
+      "react",
+      "es2015",
+      "stage-0"
+    ],
     "plugins": [
-      "add-module-exports", 
+      "add-module-exports",
       "transform-object-assign",
       "babel-plugin-root-import"
     ]
@@ -34,6 +38,11 @@
   },
   "devDependencies": {
     "babel-plugin-root-import": "^5.1.0",
+    "eslint": "^3.19.0",
+    "eslint-config-airbnb": "^14.1.0",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^4.0.0",
+    "eslint-plugin-react": "^6.10.3",
     "gh-pages": "^0.12.0"
   },
   "keywords": [

--- a/aid/pages/_template.jsx
+++ b/aid/pages/_template.jsx
@@ -5,6 +5,7 @@ import { prefixLink } from 'gatsby-helpers'
 import Headroom from 'react-headroom'
 import Helmet from 'react-helmet'
 
+import { config } from 'config'
 import { rhythm } from '../utils/typography'
 
 import '~/styles/index'
@@ -20,8 +21,10 @@ module.exports = React.createClass({
     return (
       <div>
 
-        <Helmet>
-          <title>AID BERKELEY</title>
+        <Helmet
+          title={`${config.siteTitle}`}
+        >
+
           <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
         </Helmet>
 

--- a/aid/pages/projects.js
+++ b/aid/pages/projects.js
@@ -5,7 +5,6 @@ import ProjectsList from 'components/ProjectsList'
 
 export default class Projects extends React.Component {
   render() {
-  console.log(JSON.stringify(this.props.route))
     const projects = this.props.route.pages.filter(page => (
       page.file.ext === 'md' && page.path.includes('/projects/')))
     

--- a/aid/styles/ProjectCard.scss
+++ b/aid/styles/ProjectCard.scss
@@ -16,7 +16,7 @@ $desktop: "only screen and (min-width: 800px)";
     position: relative;
 
     * { margin: 0; }
-    > .titles {
+    > .card-titles {
         border-left: solid 8px;
         padding-left: 28px;
     }
@@ -42,17 +42,17 @@ $desktop: "only screen and (min-width: 800px)";
     padding: 24px 36px 24px 36px;
 
     &:nth-child(3n+1) {
-        > .titles { border-color: $accent1; }
+        > .card-titles { border-color: $accent1; }
         > .card-body > a { background-color: $accent1; }
     }
 
     &:nth-child(3n+2) {
-        > .titles { border-color: $accent2; }
+        > .card-titles { border-color: $accent2; }
         > .card-body > a { background-color: $accent2; }
     }
 
     &:nth-child(3n+3) {
-        > .titles { border-color: $accent3; }
+        > .card-titles { border-color: $accent3; }
         > .card-body > a { background-color: $accent3; }
     }
 

--- a/aid/utils/projects-helpers.js
+++ b/aid/utils/projects-helpers.js
@@ -1,0 +1,25 @@
+const DEFAULT_IMAGE = '/assets/images/card1.png'
+
+function getBackgroundImage(post) {
+  if ('image' in post.data && post.data.image !== '') {
+    return post.path + post.data.image
+  } else {
+    return DEFAULT_IMAGE
+  }
+}
+
+function getReadMoreUrl(post) {
+  if ('url' in post.data && post.data.url !== '') {
+    return post.data.url
+  } else if (post.data.body !== '') {
+    return post.path
+  } else {
+    return undefined
+  }
+}
+
+
+module.exports = {
+  getBackgroundImage : getBackgroundImage,
+  getReadMoreUrl : getReadMoreUrl
+}

--- a/aid/wrappers/md.js
+++ b/aid/wrappers/md.js
@@ -12,14 +12,32 @@ module.exports = React.createClass({
   },
   render () {
     const post = this.props.route.page.data
+    const dirname = this.props.route.page.file
+
     return (
-      <div className="markdown">
-        <Helmet
-          title={`${config.siteTitle} | ${post.title}`}
-        />
-        <h1>{post.title}</h1>
-        <div dangerouslySetInnerHTML={{ __html: post.body }} />
+      <div className="content">
+        <div className="markdown">
+          <Helmet
+            title={`${config.siteTitle} | ${post.title}`}
+          />
+          <h1>{post.title}</h1>
+          <div dangerouslySetInnerHTML={{ __html: post.body }} />
+        </div>
       </div>
     )
   },
 })
+
+class ProjectPageWrapper extends React.Component {
+  render() {
+    const post = this.props.route.page.data
+    return (
+      <div className="ProjectContent">
+        post.title
+        post.subtitle
+        post.description
+        
+      </div>
+    )
+  }
+}


### PR DESCRIPTION
Additions:
- Use config.toml to define site metadata, front matter
- utils/project-helpers.js for some project page-related helper
  functions
- Start on the wrappers for formatting .md files (ie, projects)

- Sorry I added a linter and added it to package.json accidentally; should not impact workflow lmao