### PR TITLE
Add more desktop stylings

### DIFF
--- a/aid/components/Navbar.jsx
+++ b/aid/components/Navbar.jsx
@@ -43,7 +43,7 @@ class Navbar extends React.Component {
 
   render() {
     const active = this.state.active ? 'active' : ''
-    const background = { backgroundColor: this.state.opaque ? 'black' : 'transparent' }
+    const background = { backgroundColor: this.state.opaque ? 'rgba(0, 0, 0, 0.8)' : 'transparent' }
 
     return (
       <Headroom

--- a/aid/styles/Event.scss
+++ b/aid/styles/Event.scss
@@ -46,6 +46,7 @@
             font-size: 32px;
         }
     }
+    
     .location, .time {
         @include flexbox(row, nowrap, flex-start, stretch);
     }
@@ -60,12 +61,23 @@
 @media #{$mobile} {
     .Event {
         @include flexbox(column, nowrap, flex-start, flex-start);
+        padding-left: 5px;
 
         .date {
             @include flexbox(row, nowrap, flex-start, flex-start);
             min-width: 100%;
+            font-size: 16px;
+            line-height: 24px;
             .day {
                 font-size: inherit;
+                &:after {
+                    content: ',\00a0';
+                    display: inline-block;
+                }
+            }
+            & > div:not(.day):after {
+                content: '\00a0';
+                display: inline-block;
             }
         }
     }

--- a/aid/styles/Navbar.scss
+++ b/aid/styles/Navbar.scss
@@ -2,6 +2,7 @@
 
 $animationDuration: 120ms;
 $navHeight: 72px;
+.body.showNav { padding-top: $navHeight; }
 .headroom {
     width: inherit;
     height: $navHeight;
@@ -37,8 +38,8 @@ $navHeight: 72px;
         transition: all $animationDuration linear;
         i {
             font-size: 24px;
-            top: 16px;
-            left: 16px;
+            top: 24px;
+            left: 24px;
             position: absolute;
             transition: opacity $animationDuration linear;
         }

--- a/aid/styles/Navbar.scss
+++ b/aid/styles/Navbar.scss
@@ -1,7 +1,7 @@
 @import 'index';
 
 $animationDuration: 120ms;
-
+$navHeight: 72px;
 .headroom {
     width: inherit;
     height: $navHeight;
@@ -110,7 +110,7 @@ $animationDuration: 120ms;
 @media #{$tablet}
 {
     .headroom {
-        height: 72px;
+        height: $navHeight;
         padding-left: 20px;
         padding-right: 12px;
 
@@ -129,8 +129,10 @@ $animationDuration: 120ms;
 
 @media #{$desktop}
 {
+    $navHeight: 88px;
+    .body.showNav { padding-top: $navHeight; }
     .headroom {
-        height: 88px;
+        height: $navHeight;
         padding-right: 20px;
 
         .logo { width: 180px; }

--- a/aid/styles/ProjectCard.scss
+++ b/aid/styles/ProjectCard.scss
@@ -1,6 +1,9 @@
 @import 'index';
 
-$desktop: "only screen and (min-width: 800px)";
+.projects {
+    margin: 0px 24px 0px 24px;
+}
+
 
 .ProjectCard {
     @include flexbox(column, nowrap, stretch, stretch);
@@ -18,7 +21,8 @@ $desktop: "only screen and (min-width: 800px)";
     * { margin: 0; }
     > .card-titles {
         border-left: solid 8px;
-        padding-left: 28px;
+        padding-left: 16px;
+        margin-bottom: 16px;
     }
     h4 {
         font-size: 30px; 
@@ -32,12 +36,10 @@ $desktop: "only screen and (min-width: 800px)";
     }
     width: 100%;
     min-height: 200px;
+    max-width: 800px;
 
-    @media #{$desktop} {
-        min-width: 720px;
-    }
-
-    margin-bottom: 48px;
+    margin: auto;
+    margin-bottom: 24px;
 
     padding: 24px 36px 24px 36px;
 
@@ -60,10 +62,8 @@ $desktop: "only screen and (min-width: 800px)";
 
         flex: 2;
         @include flexbox(column, nowrap, flex-start, flex-start);
-        @media #{$desktop} {
-            @include flexbox(row, nowrap, space-between, flex-end);
-        }
-        padding-left: 36px;
+
+        padding-left: 24px;
         > p {
 
             font-size: 18px;
@@ -73,12 +73,11 @@ $desktop: "only screen and (min-width: 800px)";
         > a {
             $width: 120px;
             $height: 48px;
-            $margin: 24px;
 
             display: block;
             width: $width;
             height: $height;
-            margin-left: $margin;
+            margin-top: 24px;
             border-radius: 5px;
             white-space: nowrap;
 
@@ -96,3 +95,17 @@ $desktop: "only screen and (min-width: 800px)";
     
 }
 
+@media #{$desktop} {
+    .ProjectCard {
+        min-width: 720px;
+        
+        > .card-titles {
+            margin-bottom: 24px;
+        }
+
+        > .card-body {
+            @include flexbox(row, nowrap, space-between, flex-end);
+            > a { margin-left: 24px; }
+        }
+    }
+}

--- a/aid/styles/index.scss
+++ b/aid/styles/index.scss
@@ -32,14 +32,6 @@ a {
     :visited { color: inherit; }
 }
 
-
-// NAVBAR
-$navHeight: 56px;
-.body.showNav {
-    padding-top: $navHeight;
-}
-
-
 // MISC
 .backdrop {
     z-index: -1;

--- a/aid/styles/media.scss
+++ b/aid/styles/media.scss
@@ -9,7 +9,7 @@ $tablet-portrait:  '(orientation: portrait)  and (min-width:  #{$tablet-cutoff})
 $tablet-landscape: '(orientation: landscape) and (min-height: #{$tablet-cutoff})';
 $tablet: $tablet-portrait, $tablet-landscape;
 
-$desktop-cutoff: 1200px;
+$desktop-cutoff: 801px;
 $desktop-portrait:  '(orientation: portrait)  and (min-width:  #{$desktop-cutoff})';
 $desktop-landscape: '(orientation: landscape) and (min-width: #{$desktop-cutoff})';
 $desktop: $desktop-portrait, $desktop-landscape;


### PR DESCRIPTION
## General:
- **Desktop cutoff is now 801px**

## Navbar:
- Moved body margins to match navbar height
- **Body margins are now located in Navbar.scss**
- Semitransparent navbar instead of solid black

## Events: 
- Dates are now inline on mobile view for responsiveness

## Projects:
- Cards now properly sized
- Smaller margins for cards
- Mobile now reflows properly

## Memes:
- Minor text fixes